### PR TITLE
feat: implement all JPA entities for initial DB structure

### DIFF
--- a/src/main/java/org/nexusscode/backend/BackendApplication.java
+++ b/src/main/java/org/nexusscode/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package org.nexusscode.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/nexusscode/backend/application/domain/Career.java
+++ b/src/main/java/org/nexusscode/backend/application/domain/Career.java
@@ -1,0 +1,5 @@
+package org.nexusscode.backend.application.domain;
+
+public enum Career {
+    NEW, EXPERIENCED
+}

--- a/src/main/java/org/nexusscode/backend/application/domain/JobApplication.java
+++ b/src/main/java/org/nexusscode/backend/application/domain/JobApplication.java
@@ -1,0 +1,40 @@
+package org.nexusscode.backend.application.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.nexusscode.backend.user.domain.User;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JobApplication {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String companyName;
+    private String jobTitle;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private LocalDate applicationDate;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Enumerated(EnumType.STRING)
+    private Career career;
+
+}

--- a/src/main/java/org/nexusscode/backend/application/domain/Status.java
+++ b/src/main/java/org/nexusscode/backend/application/domain/Status.java
@@ -1,0 +1,5 @@
+package org.nexusscode.backend.application.domain;
+
+public enum Status {
+    IN_PROGRESS, SUBMITTED, PASSED, FAILED
+}

--- a/src/main/java/org/nexusscode/backend/application/repository/JobApplicationRepository.java
+++ b/src/main/java/org/nexusscode/backend/application/repository/JobApplicationRepository.java
@@ -1,0 +1,8 @@
+package org.nexusscode.backend.application.repository;
+
+import org.nexusscode.backend.application.domain.JobApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobApplicationRepository extends JpaRepository<JobApplication, Long> {
+
+}

--- a/src/main/java/org/nexusscode/backend/global/config/CustomServletConfig.java
+++ b/src/main/java/org/nexusscode/backend/global/config/CustomServletConfig.java
@@ -1,0 +1,18 @@
+package org.nexusscode.backend.global.config;
+
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class CustomServletConfig implements WebMvcConfigurer {
+
+     @Override
+     public void addCorsMappings(CorsRegistry registry) {
+         registry.addMapping("/**")
+                 .allowedOrigins("*")
+                 .allowedMethods("HEAD", "GET", "POST", "PUT", "DELETE", "OPTIONS")
+                 .maxAge(300)
+                 .allowedHeaders("Authorization", "Cache-Control", "Content-Type");
+     }
+
+}

--- a/src/main/java/org/nexusscode/backend/interview/domain/AnswerFeedback.java
+++ b/src/main/java/org/nexusscode/backend/interview/domain/AnswerFeedback.java
@@ -1,0 +1,29 @@
+package org.nexusscode.backend.interview.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnswerFeedback {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answer_id")
+    private InterviewAnswer answer;
+
+    @Column(columnDefinition = "TEXT")
+    private String feedbackText;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}
+

--- a/src/main/java/org/nexusscode/backend/interview/domain/InterviewAnswer.java
+++ b/src/main/java/org/nexusscode/backend/interview/domain/InterviewAnswer.java
@@ -1,0 +1,35 @@
+package org.nexusscode.backend.interview.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.nexusscode.backend.user.domain.User;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewAnswer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private InterviewQuestion question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String audioUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String transcript;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/nexusscode/backend/interview/domain/InterviewQuestion.java
+++ b/src/main/java/org/nexusscode/backend/interview/domain/InterviewQuestion.java
@@ -1,0 +1,29 @@
+package org.nexusscode.backend.interview.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewQuestion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private InterviewSession session;
+
+    @Column(columnDefinition = "TEXT")
+    private String questionText;
+
+    private String ttsUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String intentText;
+
+    private int order;
+}

--- a/src/main/java/org/nexusscode/backend/interview/domain/InterviewSession.java
+++ b/src/main/java/org/nexusscode/backend/interview/domain/InterviewSession.java
@@ -1,0 +1,33 @@
+package org.nexusscode.backend.interview.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.nexusscode.backend.application.domain.JobApplication;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewSession {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "application_id")
+    private JobApplication application;
+
+    private String title;
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
+
+    @Enumerated(EnumType.STRING)
+    private InterviewType interviewType;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/nexusscode/backend/interview/domain/InterviewSummary.java
+++ b/src/main/java/org/nexusscode/backend/interview/domain/InterviewSummary.java
@@ -1,0 +1,33 @@
+package org.nexusscode.backend.interview.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.nexusscode.backend.user.domain.User;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewSummary {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private InterviewSession session;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(columnDefinition = "TEXT")
+    private String summary;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/nexusscode/backend/interview/domain/InterviewType.java
+++ b/src/main/java/org/nexusscode/backend/interview/domain/InterviewType.java
@@ -1,0 +1,5 @@
+package org.nexusscode.backend.interview.domain;
+
+public enum InterviewType {
+    PERSONALITY, TECHNICAL
+}

--- a/src/main/java/org/nexusscode/backend/interview/repository/AnswerFeedbackRepository.java
+++ b/src/main/java/org/nexusscode/backend/interview/repository/AnswerFeedbackRepository.java
@@ -1,0 +1,7 @@
+package org.nexusscode.backend.interview.repository;
+
+import org.nexusscode.backend.interview.domain.AnswerFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerFeedbackRepository extends JpaRepository<AnswerFeedback, Long> {
+}

--- a/src/main/java/org/nexusscode/backend/interview/repository/InterviewAnswerRepository.java
+++ b/src/main/java/org/nexusscode/backend/interview/repository/InterviewAnswerRepository.java
@@ -1,0 +1,7 @@
+package org.nexusscode.backend.interview.repository;
+
+import org.nexusscode.backend.interview.domain.InterviewAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewAnswerRepository extends JpaRepository<InterviewAnswer, Long> {
+}

--- a/src/main/java/org/nexusscode/backend/interview/repository/InterviewQuestionRepository.java
+++ b/src/main/java/org/nexusscode/backend/interview/repository/InterviewQuestionRepository.java
@@ -1,0 +1,7 @@
+package org.nexusscode.backend.interview.repository;
+
+import org.nexusscode.backend.interview.domain.InterviewQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewQuestionRepository extends JpaRepository<InterviewQuestion, Long> {
+}

--- a/src/main/java/org/nexusscode/backend/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/org/nexusscode/backend/interview/repository/InterviewSessionRepository.java
@@ -1,0 +1,7 @@
+package org.nexusscode.backend.interview.repository;
+
+import org.nexusscode.backend.interview.domain.InterviewSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewSessionRepository extends JpaRepository<InterviewSession, Long> {
+}

--- a/src/main/java/org/nexusscode/backend/interview/repository/InterviewSummaryRepository.java
+++ b/src/main/java/org/nexusscode/backend/interview/repository/InterviewSummaryRepository.java
@@ -1,0 +1,7 @@
+package org.nexusscode.backend.interview.repository;
+
+import org.nexusscode.backend.interview.domain.InterviewSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewSummaryRepository extends JpaRepository<InterviewSummary, Long> {
+}

--- a/src/main/java/org/nexusscode/backend/memo/domain/ApplicationMemo.java
+++ b/src/main/java/org/nexusscode/backend/memo/domain/ApplicationMemo.java
@@ -1,0 +1,40 @@
+package org.nexusscode.backend.memo.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.nexusscode.backend.application.domain.JobApplication;
+import org.nexusscode.backend.user.domain.User;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApplicationMemo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "application_id")
+    private JobApplication application;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private boolean pinned;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/nexusscode/backend/memo/repository/ApplicationMemoRepository.java
+++ b/src/main/java/org/nexusscode/backend/memo/repository/ApplicationMemoRepository.java
@@ -1,0 +1,7 @@
+package org.nexusscode.backend.memo.repository;
+
+import org.nexusscode.backend.memo.domain.ApplicationMemo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationMemoRepository extends JpaRepository<ApplicationMemo, Long> {
+}

--- a/src/main/java/org/nexusscode/backend/resume/domain/Resume.java
+++ b/src/main/java/org/nexusscode/backend/resume/domain/Resume.java
@@ -1,0 +1,29 @@
+package org.nexusscode.backend.resume.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.nexusscode.backend.application.domain.JobApplication;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Resume {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "application_id")
+    private JobApplication application;
+
+    private String title;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}
+

--- a/src/main/java/org/nexusscode/backend/resume/domain/ResumeItem.java
+++ b/src/main/java/org/nexusscode/backend/resume/domain/ResumeItem.java
@@ -1,0 +1,29 @@
+package org.nexusscode.backend.resume.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResumeItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @Column(columnDefinition = "TEXT")
+    private String question;
+
+    @Column(columnDefinition = "TEXT")
+    private String answer;
+
+    private int order;
+    private int wordLimit;
+
+}

--- a/src/main/java/org/nexusscode/backend/resume/domain/ResumeItemFeedback.java
+++ b/src/main/java/org/nexusscode/backend/resume/domain/ResumeItemFeedback.java
@@ -1,0 +1,29 @@
+package org.nexusscode.backend.resume.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResumeItemFeedback {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_item_id")
+    private ResumeItem resumeItem;
+
+    @Column(columnDefinition = "TEXT")
+    private String feedbackText;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/nexusscode/backend/resume/repository/ResumeItemFeedbackRepository.java
+++ b/src/main/java/org/nexusscode/backend/resume/repository/ResumeItemFeedbackRepository.java
@@ -1,0 +1,7 @@
+package org.nexusscode.backend.resume.repository;
+
+import org.nexusscode.backend.resume.domain.ResumeItemFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeItemFeedbackRepository extends JpaRepository<ResumeItemFeedback, Long> {
+}

--- a/src/main/java/org/nexusscode/backend/resume/repository/ResumeItemRepository.java
+++ b/src/main/java/org/nexusscode/backend/resume/repository/ResumeItemRepository.java
@@ -1,0 +1,7 @@
+package org.nexusscode.backend.resume.repository;
+
+import org.nexusscode.backend.resume.domain.ResumeItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeItemRepository extends JpaRepository<ResumeItem, Long> {
+}

--- a/src/main/java/org/nexusscode/backend/resume/repository/ResumeRepository.java
+++ b/src/main/java/org/nexusscode/backend/resume/repository/ResumeRepository.java
@@ -1,0 +1,7 @@
+package org.nexusscode.backend.resume.repository;
+
+import org.nexusscode.backend.resume.domain.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+}

--- a/src/main/java/org/nexusscode/backend/user/domain/MemberRole.java
+++ b/src/main/java/org/nexusscode/backend/user/domain/MemberRole.java
@@ -1,0 +1,5 @@
+package org.nexusscode.backend.user.domain;
+
+public enum MemberRole {
+    USER, ADMIN
+}

--- a/src/main/java/org/nexusscode/backend/user/domain/User.java
+++ b/src/main/java/org/nexusscode/backend/user/domain/User.java
@@ -1,0 +1,40 @@
+package org.nexusscode.backend.user.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/org/nexusscode/backend/user/repository/UserRepository.java
+++ b/src/main/java/org/nexusscode/backend/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package org.nexusscode.backend.user.repository;
+
+import org.nexusscode.backend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
feat: implement all JPA entities for initial DB structure

- User
- JobApplication
- Resume, ResumeItem, ResumeItemFeedback
- InterviewSession, InterviewQuestion, InterviewAnswer, AnswerFeedback, InterviewSummary
- ApplicationMemo
- 모든 엔티티에 JPA 매핑 및 연관 관계 정의 완료
