### PR TITLE
feat(interview): 면접 세션 생성 및 질문 생성/조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,13 @@ repositories {
 }
 
 dependencies {
+    implementation(platform("org.springframework.ai:spring-ai-bom:1.0.0-M6"))
+    implementation("org.springframework.ai:spring-ai-openai-spring-boot-starter")
+    implementation("org.springframework.ai:spring-ai-openai:1.0.0-M6")
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/org/nexusscode/backend/application/domain/JobApplication.java
+++ b/src/main/java/org/nexusscode/backend/application/domain/JobApplication.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.nexusscode.backend.user.domain.User;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class JobApplication {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/nexusscode/backend/global/config/OpenAIConfig.java
+++ b/src/main/java/org/nexusscode/backend/global/config/OpenAIConfig.java
@@ -1,0 +1,65 @@
+package org.nexusscode.backend.global.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Configuration
+public class OpenAIConfig {
+
+    @Value("${spring.ai.openai.api-key}")
+    private String openAITTSApiKey;
+
+    @Value("${org.nexusscode.openAITTS.tts-endpoint}")
+    private String ttsEndpoint;
+
+    @Value("${spring.ai.openai.api-key}")
+    private String openAIWhisperApiKey;
+
+    @Value("${org.nexusscode.openAIWhisper.whisper-endpoint}")
+    private String whisperEndpoint;
+
+    @Bean
+    public ChatClient chatClient(ChatModel model) {
+        return ChatClient.create(model);
+    }
+
+    @Bean
+    @Qualifier("openAiWebClient")
+    public WebClient openAiWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://api.openai.com")
+                .build();
+    }
+
+    @Bean
+    @Qualifier("openAiTTSWebClient")
+    public WebClient openAiTTSWebClient() {
+        return WebClient.builder()
+                .baseUrl(ttsEndpoint)
+                .defaultHeader("Authorization", "Bearer " + openAITTSApiKey)
+                .defaultHeader("Content-Type", "application/json")
+                .clientConnector(new ReactorClientHttpConnector(
+                        HttpClient.create()
+                                .responseTimeout(Duration.ofSeconds(30))
+                ))
+                .build();
+    }
+
+    @Bean
+    @Qualifier("openaiTranscriptionWebClient")
+    public WebClient openaiTranscriptionWebClient() {
+        return WebClient.builder()
+                .baseUrl(whisperEndpoint)
+                .defaultHeader("Authorization", "Bearer " + openAIWhisperApiKey)
+                .build();
+    }
+}

--- a/src/main/java/org/nexusscode/backend/interview/client/GPTClient.java
+++ b/src/main/java/org/nexusscode/backend/interview/client/GPTClient.java
@@ -1,0 +1,77 @@
+package org.nexusscode.backend.interview.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.nexusscode.backend.interview.dto.InterviewQuestionDTO;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class GPTClient {
+
+    private final ChatClient chatClient;
+
+    public List<InterviewQuestionDTO> generateInterviewQuestions(String resumeText) {
+        PromptTemplate promptTemplate = buildPrompt();
+        String prompt = promptTemplate.create(Map.of("resume", resumeText)).toString();
+
+        String content = chatClient
+                .prompt()
+                .user(prompt)
+                .call()
+                .content();
+
+        return parseQuestionsFrom(content);
+    }
+
+    private PromptTemplate buildPrompt() {
+        return new PromptTemplate("""
+            아래는 한 사람의 자기소개서입니다.
+
+            이 내용을 바탕으로, 예상 면접 질문 5개와 각 질문의 의도를 알려주세요.
+
+            형식 예:
+            질문: ~~~
+            의도: ~~~
+
+            자기소개서:
+            {resume}
+        """);
+    }
+
+    private List<InterviewQuestionDTO> parseQuestionsFrom(String gptOutput) {
+        List<InterviewQuestionDTO> result = new ArrayList<>();
+        String[] blocks = gptOutput.split("(?=질문\\s*\\d*:)");
+
+        for (String block : blocks) {
+            String question = null;
+            String intent = null;
+
+            for (String line : block.strip().split("\\r?\\n")) {
+                if (line.matches("^질문\\s*\\d*:\\s*.*")) {
+                    question = line.replaceFirst("^질문\\s*\\d*:\\s*", "").trim();
+                } else if (line.startsWith("의도:")) {
+                    intent = line.replaceFirst("의도:", "").trim();
+                }
+            }
+
+            if (question != null && intent != null) {
+                result.add(InterviewQuestionDTO.builder()
+                        .question(question)
+                        .intent(intent)
+                        .build());
+            }
+        }
+
+        return result;
+    }
+
+}
+

--- a/src/main/java/org/nexusscode/backend/interview/client/OpenAITTSClient.java
+++ b/src/main/java/org/nexusscode/backend/interview/client/OpenAITTSClient.java
@@ -1,0 +1,31 @@
+package org.nexusscode.backend.interview.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class OpenAITTSClient {
+
+    private final WebClient openAITTSWebClient;
+
+    public OpenAITTSClient(@Qualifier("openAiTTSWebClient") WebClient openAITTSWebClient) {
+        this.openAITTSWebClient = openAITTSWebClient;
+    }
+
+    public byte[] textToSpeech(String text, String voice, String instructions) {
+        TTSRequest requestBody = new TTSRequest("gpt-4o-mini-tts", text, voice, instructions);
+
+        return openAITTSWebClient.post()
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(byte[].class)
+                .block();
+    }
+
+    private record TTSRequest(String model, String input, String voice, String instructions) {}
+}

--- a/src/main/java/org/nexusscode/backend/interview/client/OpenAiWhisperClient.java
+++ b/src/main/java/org/nexusscode/backend/interview/client/OpenAiWhisperClient.java
@@ -1,0 +1,36 @@
+package org.nexusscode.backend.interview.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class OpenAiWhisperClient {
+
+    private final WebClient webClient;
+
+    public OpenAiWhisperClient(@Qualifier("openaiTranscriptionWebClient") WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    public String transcribe(String filePath) {
+        FileSystemResource audioFile = new FileSystemResource(filePath);
+
+        return webClient.post()
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData("file", audioFile)
+                        .with("model", "gpt-4o-transcribe"))
+                .retrieve()
+                .bodyToMono(TranscriptionResponse.class)
+                .map(TranscriptionResponse::text)
+                .block();
+    }
+
+    private record TranscriptionResponse(String text) {}
+}

--- a/src/main/java/org/nexusscode/backend/interview/controller/InterviewController.java
+++ b/src/main/java/org/nexusscode/backend/interview/controller/InterviewController.java
@@ -1,0 +1,37 @@
+package org.nexusscode.backend.interview.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.nexusscode.backend.interview.dto.InterviewQuestionDTO;
+import org.nexusscode.backend.interview.dto.InterviewSessionDTO;
+import org.nexusscode.backend.interview.dto.InterviewStartRequest;
+import org.nexusscode.backend.interview.dto.QuestionAndHintDTO;
+import org.nexusscode.backend.interview.service.InterviewService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@Log4j2
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/interview")
+public class InterviewController {
+
+    private final InterviewService interviewService;
+
+    @PostMapping("/start")
+    public ResponseEntity<Long> startInterview(@RequestBody InterviewStartRequest request) {
+        return ResponseEntity.ok(interviewService.startInterview(request.getTitle(), request.getResumeId()));
+    }
+
+    @GetMapping("/{sessionId}/question")
+    public ResponseEntity<QuestionAndHintDTO> getQuestion(@PathVariable Long sessionId, @RequestParam Integer seq) {
+        return ResponseEntity.ok(interviewService.getQuestion(sessionId, seq));
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<List<InterviewSessionDTO>> list(Long applicationId) {
+        return ResponseEntity.ok(interviewService.getList());
+    }
+}

--- a/src/main/java/org/nexusscode/backend/interview/domain/AnswerFeedback.java
+++ b/src/main/java/org/nexusscode/backend/interview/domain/AnswerFeedback.java
@@ -3,6 +3,7 @@ package org.nexusscode.backend.interview.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class AnswerFeedback {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/nexusscode/backend/interview/domain/InterviewAnswer.java
+++ b/src/main/java/org/nexusscode/backend/interview/domain/InterviewAnswer.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.nexusscode.backend.user.domain.User;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class InterviewAnswer {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/nexusscode/backend/interview/domain/InterviewSession.java
+++ b/src/main/java/org/nexusscode/backend/interview/domain/InterviewSession.java
@@ -4,14 +4,18 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.nexusscode.backend.application.domain.JobApplication;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class InterviewSession {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,4 +34,20 @@ public class InterviewSession {
 
     @CreatedDate
     private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "session", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<InterviewQuestion> questions = new ArrayList<>();
+
+    public static InterviewSession createInterviewSession(JobApplication application, String title, List<InterviewQuestion> questions) {
+        InterviewSession build = InterviewSession.builder()
+                .application(application)
+                .title(title)
+                .startedAt(LocalDateTime.now())
+                .build();
+
+        build.questions.addAll(questions);
+
+        return build;
+    }
 }

--- a/src/main/java/org/nexusscode/backend/interview/domain/InterviewSummary.java
+++ b/src/main/java/org/nexusscode/backend/interview/domain/InterviewSummary.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.nexusscode.backend.user.domain.User;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class InterviewSummary {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/nexusscode/backend/interview/dto/InterviewQuestionDTO.java
+++ b/src/main/java/org/nexusscode/backend/interview/dto/InterviewQuestionDTO.java
@@ -1,0 +1,13 @@
+package org.nexusscode.backend.interview.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+
+@Builder
+@Data
+@ToString
+public class InterviewQuestionDTO {
+    String question;
+    String intent;
+}

--- a/src/main/java/org/nexusscode/backend/interview/dto/InterviewSessionDTO.java
+++ b/src/main/java/org/nexusscode/backend/interview/dto/InterviewSessionDTO.java
@@ -1,0 +1,10 @@
+package org.nexusscode.backend.interview.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class InterviewSessionDTO {
+    private String sessionId;
+}

--- a/src/main/java/org/nexusscode/backend/interview/dto/InterviewStartRequest.java
+++ b/src/main/java/org/nexusscode/backend/interview/dto/InterviewStartRequest.java
@@ -1,0 +1,11 @@
+package org.nexusscode.backend.interview.dto;
+
+
+import lombok.Data;
+
+@Data
+public class InterviewStartRequest {
+    private Long resumeId;
+    private String title;
+    private String interviewType;
+}

--- a/src/main/java/org/nexusscode/backend/interview/dto/QuestionAndHintDTO.java
+++ b/src/main/java/org/nexusscode/backend/interview/dto/QuestionAndHintDTO.java
@@ -1,0 +1,13 @@
+package org.nexusscode.backend.interview.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class QuestionAndHintDTO {
+    private Long interviewQuestionId;
+    private String questionText;
+    private String intentText;
+    private Integer seq;
+}

--- a/src/main/java/org/nexusscode/backend/interview/repository/InterviewQuestionRepository.java
+++ b/src/main/java/org/nexusscode/backend/interview/repository/InterviewQuestionRepository.java
@@ -2,6 +2,14 @@ package org.nexusscode.backend.interview.repository;
 
 import org.nexusscode.backend.interview.domain.InterviewQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface InterviewQuestionRepository extends JpaRepository<InterviewQuestion, Long> {
+
+    @Query("SELECT q FROM InterviewQuestion q WHERE q.session.id = :sessionId AND q.seq = :seq")
+    Optional<InterviewQuestion> findBySessionIdAndSeq(@Param("sessionId") Long sessionId, @Param("seq") int seq);
+
 }

--- a/src/main/java/org/nexusscode/backend/interview/service/InterviewService.java
+++ b/src/main/java/org/nexusscode/backend/interview/service/InterviewService.java
@@ -1,0 +1,16 @@
+package org.nexusscode.backend.interview.service;
+
+import org.nexusscode.backend.interview.dto.InterviewQuestionDTO;
+import org.nexusscode.backend.interview.dto.InterviewSessionDTO;
+import org.nexusscode.backend.interview.dto.QuestionAndHintDTO;
+
+import java.util.List;
+
+public interface InterviewService {
+
+    Long startInterview(String title, Long resumeId);
+
+    List<InterviewSessionDTO> getList();
+
+    QuestionAndHintDTO getQuestion(Long sessionId, Integer seq);
+}

--- a/src/main/java/org/nexusscode/backend/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/org/nexusscode/backend/interview/service/InterviewServiceImpl.java
@@ -1,0 +1,90 @@
+package org.nexusscode.backend.interview.service;
+
+import lombok.RequiredArgsConstructor;
+import org.nexusscode.backend.interview.client.GPTClient;
+import org.nexusscode.backend.interview.domain.InterviewQuestion;
+import org.nexusscode.backend.interview.domain.InterviewSession;
+import org.nexusscode.backend.interview.dto.InterviewQuestionDTO;
+import org.nexusscode.backend.interview.dto.InterviewSessionDTO;
+import org.nexusscode.backend.interview.dto.QuestionAndHintDTO;
+import org.nexusscode.backend.interview.repository.InterviewQuestionRepository;
+import org.nexusscode.backend.interview.repository.InterviewSessionRepository;
+import org.nexusscode.backend.resume.domain.Resume;
+import org.nexusscode.backend.resume.domain.ResumeItem;
+import org.nexusscode.backend.resume.repository.ResumeItemRepository;
+import org.nexusscode.backend.resume.repository.ResumeRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewServiceImpl implements InterviewService{
+
+    private final ResumeRepository resumeRepository;
+    private final ResumeItemRepository resumeItemRepository;
+    private final GPTClient gptClient;
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final InterviewQuestionRepository interviewQuestionRepository;
+
+    @Override
+    public Long startInterview(String title, Long resumeId) {
+        Resume resume = resumeRepository.findById(resumeId).orElseThrow();
+        List<ResumeItem> items = resumeItemRepository.findByResumeId(resume.getId());
+
+        String resumeText = makeResumeText(items);
+        List<InterviewQuestionDTO> gptQuestions = gptClient.generateInterviewQuestions(resumeText);
+        
+        List<InterviewQuestion> questions = mapToInterviewQuestions(gptQuestions);
+
+        InterviewSession interviewSession = InterviewSession.createInterviewSession(
+                resume.getApplication(), title, questions
+        );
+
+        Long sessionId = interviewSessionRepository.save(interviewSession).getId();
+
+        return sessionId;
+    }
+
+    private String makeResumeText(List<ResumeItem> items) {
+        StringBuilder sb = new StringBuilder();
+        for (ResumeItem item : items) {
+            sb.append("Q: ").append(item.getQuestion()).append("\n");
+            sb.append("A: ").append(item.getAnswer()).append("\n\n");
+        }
+        return sb.toString();
+    }
+
+    private List<InterviewQuestion> mapToInterviewQuestions(List<InterviewQuestionDTO> dtos) {
+        AtomicInteger counter = new AtomicInteger(0);
+
+        return dtos.stream()
+                .map(dto -> InterviewQuestion.builder()
+                        .questionText(dto.getQuestion())
+                        .intentText(dto.getIntent())
+                        .seq(counter.getAndIncrement())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public QuestionAndHintDTO getQuestion(Long sessionId, Integer seq) {
+        InterviewQuestion interviewQuestion = interviewQuestionRepository.findBySessionIdAndSeq(sessionId, seq).orElseThrow();
+
+        return QuestionAndHintDTO.builder()
+                .interviewQuestionId(interviewQuestion.getId())
+                .questionText(interviewQuestion.getQuestionText())
+                .intentText(interviewQuestion.getIntentText())
+                .seq(interviewQuestion.getSeq())
+                .build();
+    }
+
+    @Override
+    public List<InterviewSessionDTO> getList() {
+        return List.of();
+    }
+}
+

--- a/src/main/java/org/nexusscode/backend/memo/domain/ApplicationMemo.java
+++ b/src/main/java/org/nexusscode/backend/memo/domain/ApplicationMemo.java
@@ -6,6 +6,7 @@ import org.nexusscode.backend.application.domain.JobApplication;
 import org.nexusscode.backend.user.domain.User;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class ApplicationMemo {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/nexusscode/backend/resume/domain/Resume.java
+++ b/src/main/java/org/nexusscode/backend/resume/domain/Resume.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.nexusscode.backend.application.domain.JobApplication;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class Resume {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/nexusscode/backend/resume/domain/ResumeItemFeedback.java
+++ b/src/main/java/org/nexusscode/backend/resume/domain/ResumeItemFeedback.java
@@ -3,6 +3,7 @@ package org.nexusscode.backend.resume.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class ResumeItemFeedback {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/nexusscode/backend/resume/repository/ResumeItemRepository.java
+++ b/src/main/java/org/nexusscode/backend/resume/repository/ResumeItemRepository.java
@@ -2,6 +2,11 @@ package org.nexusscode.backend.resume.repository;
 
 import org.nexusscode.backend.resume.domain.ResumeItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ResumeItemRepository extends JpaRepository<ResumeItem, Long> {
+    @Query("select ri from ResumeItem ri where ri.resume.id = :id order by ri.id")
+    List<ResumeItem> findByResumeId(Long id);
 }

--- a/src/main/java/org/nexusscode/backend/user/domain/User.java
+++ b/src/main/java/org/nexusscode/backend/user/domain/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
feat(interview): 면접 세션 생성 및 질문 생성/조회 API 구현

- 면접 세션 생성 API 구현 (/api/v1/interview/start)
- GPT를 통해 자기소개서 기반 질문 및 의도(힌트) 생성
- 생성된 질문들을 DB에 저장
- 프론트에서 seq 기반으로 질문/힌트 하나씩 조회하는 API 추가
